### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/src/rpn-eval.rs
+++ b/src/rpn-eval.rs
@@ -60,6 +60,6 @@ fn main() -> std::io::Result<()> {
         reader.consume(consumed);
     }
     assert!(stack.len() == 1);
-    println!("{:.}", stack[0]);
+    println!("{}", stack[0]);
     Ok(())
 }


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.